### PR TITLE
Disallow clippy warnings

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --tests --benches -- -D clippy::all
+        run: cargo clippy --tests --benches -- -D clippy::all -D warnings
 
       - name: Build
         run: wasm-pack build --target web --out-dir dist --release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub fn verify_ic_signature(
 }
 
 fn root_public_key_from_bytes(ic_root_public_key: &[u8]) -> Result<IcRootOfTrust, String> {
-    let root_key_bytes: [u8; 96] = ic_root_public_key.clone().try_into().map_err(|_| {
+    let root_key_bytes: [u8; 96] = ic_root_public_key.try_into().map_err(|_| {
         format!(
             "Invalid length of ic root public key: expected 96 bytes, got {}",
             ic_root_public_key.len()


### PR DESCRIPTION
This PR changes CI to fail on clippy warnings and also fixes the existing clippy warning.