### PR TITLE
Fix tag pattern for the release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-*'
 
 jobs:
   release:


### PR DESCRIPTION
It turns out that GitHub does not use regex, but a restricted pattern syntax specified here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

The new pattern should trigger on all tags with prefix `release-`.