### PR TITLE
Set up node in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install Rust
         run: |
           rustup update ${{ matrix.rust }} --no-self-update


### PR DESCRIPTION
The previous release job failed because the preinstalled node installation on github actions runner is not configured correctly to publish packages.
The setup node action apparently does it right, according to @nathanosdev who has done it before.