### PR TITLE
Add @dfinity scope to npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo install wasm-pack
 
       - name: Build
-        run: wasm-pack build --target web --out-dir dist --release
+        run: wasm-pack build --target web --out-dir dist --release --scope dfinity
 
       - name: Create Github release
         uses: ncipollo/release-action@v1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ JS/TS Wrapper for the `ic-standalone-sig-verifier` rust crate ([code](https://gi
 ## Building
 Run the following command
 ```bash
-wasm-pack build --target web --out-dir dist --release
+wasm-pack build --target web --out-dir dist --release --scope dfinity
 ```
 ## Usage Example
 


### PR DESCRIPTION
Without the scope, the npm package is published as-is, without the required association to dfinity.