### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
         rust: [ 1.73.0 ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Cache Cargo
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
@@ -39,7 +39,7 @@ jobs:
         run: wasm-pack build --target web --out-dir dist --release --scope dfinity
 
       - name: Create Github release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: '${{ github.ref_name }}'
           commit: 'main'


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions/cache@v3` -> `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `actions/setup-node@v3` -> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1`
  - Version: v3.9.1 | Latest: v6.3.0 | Release age: 36d
  - Commit: https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610

- `ncipollo/release-action@v1` -> `ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0`
  - Version: v1.21.0 | Latest: v1.21.0 | Release age: 25d
  - Commit: https://github.com/ncipollo/release-action/commit/339a81892b84b4eeb0f6e744e4574d79d0d9b8dd


### Files modified

- `.github/workflows/pull_request.yml`
- `.github/workflows/release.yml`